### PR TITLE
Add more output file control to the user exporting from Fusion

### DIFF
--- a/tools/fusion-electronics-export.ulp
+++ b/tools/fusion-electronics-export.ulp
@@ -9,9 +9,16 @@ string Version = "1.0";
        "<p>"
        "Run once from the schematic editor, then again from the board editor."
        "<p>"
-       "Output: &lt;repo&gt;/exports/&lt;design_name&gt;-thomson-export-sch.json"
+       "<b>Usage:</b>"
+       "<blockquote>run fusion-electronics-export [-d]<br>"
+       "run fusion-electronics-export -o filename<br>"
+       "<b>Flags:</b>"
+       "<blockquote>d: show a file dialog to specify the output file<br>"
+       "o: specify the output filename directly on the command line<br></blockquote>"
+       "The output path and filename is automatically calculated if no options are specified:<br>"
+       "Schematics: &lt;repo&gt;/exports/&lt;design_name&gt;-thomson-export-sch.json"
        "<br>"
-       "Output: &lt;repo&gt;/exports/&lt;design_name&gt;-thomson-export-brd.json"
+       "Layout: &lt;repo&gt;/exports/&lt;design_name&gt;-thomson-export-brd.json"
        "<p>"
        "<author>Author: ThomsonLint project</author>"
 
@@ -21,14 +28,41 @@ string Version = "1.0";
 // Run from schematic editor for -sch.json, from board editor for -brd.json.
 // ============================================================================
 
+enum { false, true };
+enum {osWindows,osLinux,osMacintosh};
 int isSchematic = 0;
 int isBoard = 0;
+string FileName;
+int useFileDialog = false;
+int useProvidedFilename = false;
+
 if (schematic) isSchematic = 1;
 if (board) isBoard = 1;
 
 if (!isSchematic && !isBoard) {
   dlgMessageBox("ERROR: This ULP must be run from the schematic or board editor.");
   exit(1);
+}
+
+// parse command line arguments
+if (argc>1)
+{
+	string flag = argv[1];
+	if (flag[0] == '-')
+	{
+		if (strlen(flag) != 2) exit(1);
+    switch (flag[1])
+    {
+      case 'd' : // use default output path
+        useFileDialog = true; 
+        break;
+      case 'o' : // use output filename provided as command line argument
+        if (argc < 3) exit(2);
+        FileName = argv[2];
+        useProvidedFilename = true;
+        break;
+    }
+  }
 }
 
 // --- Extract base design name from a path (no builtin filename()) ---
@@ -92,29 +126,40 @@ string extractDir(string fullpath) {
   return "";
 }
 
-// --- Build dynamic output filename from design name ---
-string designName = "";
-if (isSchematic) {
-  schematic(SCH) {
-    // DEBUG: uncomment to see what SCH.name returns in Fusion Electronics
-    // dlgMessageBox("SCH.name = " + SCH.name);
-    designName = extractBaseName(SCH.name);
+// determine output file path
+if (useFileDialog) {
+  // Present a save file dialog to the user
+  string FileSuffix = isSchematic ? "-thomson-export-sch.json" : "-thomson-export-brd.json";
+  FileName = dlgFileSave("Save JSON File", "", FileSuffix);
+  if (FileName == "") {
+    exit(0);
   }
-}
-if (isBoard) {
-  board(B) {
-    // DEBUG: uncomment to see what B.name returns in Fusion Electronics
-    // dlgMessageBox("B.name = " + B.name);
-    designName = extractBaseName(B.name);
+  FileName += FileSuffix;
+} else if (useProvidedFilename == false) {
+  string FileSuffix = isSchematic ? "-thomson-export-sch.json" : "-thomson-export-brd.json";
+  string ulpDir = extractDir(argv[0]);   // <clone>/tools
+  string repoDir = extractDir(ulpDir);    // <clone>
+  string exportDir = repoDir + "/exports";
+  
+  // --- Build dynamic output filename from design name ---
+  string designName = "";
+  if (isSchematic) {
+    schematic(SCH) {
+      // DEBUG: uncomment to see what SCH.name returns in Fusion Electronics
+      // dlgMessageBox("SCH.name = " + SCH.name);
+      designName = extractBaseName(SCH.name);
+    }
   }
+  if (isBoard) {
+    board(B) {
+      // DEBUG: uncomment to see what B.name returns in Fusion Electronics
+      // dlgMessageBox("B.name = " + B.name);
+      designName = extractBaseName(B.name);
+    }
+  }
+  
+  FileName = exportDir + "/" + designName + FileSuffix;
 }
-if (strlen(designName) == 0) designName = "unknown";
-
-string FileSuffix = isSchematic ? "-thomson-export-sch.json" : "-thomson-export-brd.json";
-string ulpDir = extractDir(argv[0]);   // <clone>/tools
-string repoDir = extractDir(ulpDir);    // <clone>
-string exportDir = repoDir + "/exports";
-string FileName = exportDir + "/" + designName + FileSuffix;
 
 // ---------------------------------------------------------------------------
 // Helper: JSON-escape a string


### PR DESCRIPTION
Add command line support to provide filename as argument or display a file dialog window. This allows the ULP to be copied outside of the project folder (e.g. to the user ULP collection) and either be called from other scripts/add-ins (which provide the path and filename), or let the user decide the location and name for each output. Preserves the default behavior if no arguments are provided.