### PR TITLE
Fix KiCad 9 net regression in KiCad 10 net-format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cd ThomsonLint
    ```
    One command per editor produces the JSON connectivity export, layer stackup JSON (board only), and high-resolution image renders. To customise output paths or DPI, run the three underlying ULPs (`fusion-electronics-export.ulp`, `fusion-electronics-stackup.ulp`, `fusion-electronics-images.ulp`) directly — see §7.
 
-**KiCad 9:**
+**KiCad 9 / 10:**
 1. Run `python tools/kicad-export.py path/to/MyProject.kicad_pro`
 
 **Then** run Claude Code from the repo root and type `/design-review` at the prompt:
@@ -83,7 +83,7 @@ The repository is organized as follows:
 -   `examples/examples.json`: A set of example hardware design scenarios for training and testing.
 -   `docs/REVIEWER_INSTRUCTIONS.md`: The single source of truth for how a review is conducted; consumed by both Claude Code and the bundled web-AI workflow.
 -   `docs/AI_Hardware_Design_Review_KnowledgeBase.md`: A detailed, human-readable knowledge base.
--   `docs/KiCad_Review_Guide.md`: Usage guide for the KiCad 9 export workflow.
+-   `docs/KiCad_Review_Guide.md`: Usage guide for the KiCad 9 / 10 export workflow.
 -   `docs/Multi_Agent_Reasoning_Spec.md`: A specification for a conceptual multi-agent reasoning architecture.
 -   `tests/ontology_schema.json`: A JSON schema for validating `ontology/ontology.json`.
 -   `tests/examples_schema.json`: A JSON schema for validating `examples/examples.json`.
@@ -93,7 +93,7 @@ The repository is organized as follows:
 -   `tools/fusion-electronics-export.ulp`: ULP that exports schematic and board connectivity/placement to JSON. Run from each editor.
 -   `tools/fusion-electronics-stackup.ulp`: ULP that exports the layer stack (copper ordering, used-vs-unused layers) to JSON. Run from the board editor.
 -   `tools/fusion-electronics-images.ulp`: ULP that renders the schematic sheets and per-layer board images as high-resolution PNGs (300 DPI schematic / 1200 DPI board defaults). Run from each editor.
--   `tools/kicad-export.py`: Standalone Python script to export KiCad 9 designs for review.
+-   `tools/kicad-export.py`: Standalone Python script to export KiCad 9 / 10 designs for review.
 -   `tools/yt-transcript.py`: Pulls a YouTube video transcript (via yt-dlp) with creator metadata in the header, as raw material for knowledge-base additions. See CLAUDE.md "Ingesting YouTube Content" — KB additions derived from a video must credit the creator (their homepage info feeds the `**Source:**` line).
 -   `tools/validate_findings.py`: Coverage validator — schema-checks the findings JSON, lists every input in `exports/` not cited in any `evidence[].source`, and flags missing required fields. Mandatory gate before generating the HTML report.
 -   `tools/gen_report.py`: Generates the self-contained HTML review report from findings JSON; embeds image evidence as inline thumbnails.
@@ -222,7 +222,7 @@ Claude Code is the tested driver for this framework. It reads the exported desig
 
 - Claude Code CLI installed and authenticated
 - ThomsonLint repository cloned locally
-- Design exported from Fusion Electronics or KiCad 9 (see below)
+- Design exported from Fusion Electronics or KiCad 9 / 10 (see below)
 
 ### Step 1: Export Design Data from Fusion Electronics
 
@@ -276,9 +276,9 @@ RUN fusion-electronics-stackup.ulp                # layer stack JSON
 RUN fusion-electronics-images.ulp                 # PNG renders (run last — it terminates the chain)
 ```
 
-### Step 1 (Alternative): Export Design Data from KiCad 9
+### Step 1 (Alternative): Export Design Data from KiCad 9 / 10
 
-If your design is in KiCad 9, use the standalone Python exporter instead:
+If your design is in KiCad 9 or KiCad 10, use the standalone Python exporter instead:
 
 ```bash
 python tools/kicad-export.py path/to/MyProject.kicad_pro
@@ -286,7 +286,7 @@ python tools/kicad-export.py path/to/MyProject.kicad_pro
 
 This generates both `-thomson-export-sch.json` and `-thomson-export-brd.json` files in the `exports/` directory. Use `--output <dir>` to specify a different output directory.
 
-The script parses KiCad 9 S-expression files directly — no KiCad installation required, Python 3.6+ standard library only. It handles hierarchical multi-sheet schematics, reads net classes from the project file, and classifies signals (power, ground, clock, differential pairs with interface detection for USB, CAN, Ethernet, HDMI, LVDS, PCIe, SATA, MIPI).
+The script parses KiCad S-expression files directly — no KiCad installation required, Python 3.6+ standard library only. It auto-detects the board net format (KiCad 9's top-level net table vs. KiCad 10's name-only inline references), handles hierarchical multi-sheet schematics, reads net classes from the project file, and classifies signals (power, ground, clock, differential pairs with interface detection for USB, CAN, Ethernet, HDMI, LVDS, PCIe, SATA, MIPI).
 
 See [`docs/KiCad_Review_Guide.md`](docs/KiCad_Review_Guide.md) for full details on the KiCad export format.
 

--- a/docs/KiCad_Review_Guide.md
+++ b/docs/KiCad_Review_Guide.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Python 3.6+ (no external dependencies)
-- KiCad 9.0+ project files (`.kicad_pro`, `.kicad_sch`, `.kicad_pcb`)
+- KiCad 9.0 or KiCad 10.0 project files (`.kicad_pro`, `.kicad_sch`, `.kicad_pcb`)
 
 ## Quick Start
 
@@ -75,4 +75,14 @@ Components are classified by reference designator prefix (U=IC, C=capacitor, R=r
 
 ## Supported Versions
 
-Tested with KiCad 9.0 file format (version 20241229 PCB, 20250114 schematic). Compatible with any KiCad 9.x project.
+Tested against real projects from both major releases:
+
+| KiCad | PCB format | Schematic format | Board net references |
+|-------|-----------|------------------|----------------------|
+| 9.0   | `20241229` | `20250114` | Top-level net table `(net N "name")`; pads/tracks/vias/zones reference nets by integer ordinal |
+| 10.0  | `20260206` | `20260306` | No net table; pads/tracks/vias/zones carry the name inline as `(net "name")` |
+
+The exporter detects the format automatically. For KiCad 10 boards (which
+dropped the net table and integer ordinals) it synthesizes sequential net
+ordinals in discovery order so the JSON output shape is identical across
+versions. Compatible with any KiCad 9.x or 10.x project.

--- a/tests/test_kicad_export.py
+++ b/tests/test_kicad_export.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Regression tests for tools/kicad-export.py net resolution (KiCad 9 & 10).
+
+Standalone, standard-library only -- run directly:
+
+    python tests/test_kicad_export.py
+
+Uses tiny inline synthetic .kicad_pcb fixtures so no real (proprietary)
+project files need to live in the repo.  Guards the two net-reference
+formats the exporter must handle:
+
+  * KiCad 9  (.kicad_pcb version 20241229): a top-level net table declares
+    (net <ordinal> "name"); pads carry (net <ordinal> "name") and
+    tracks/vias/zones carry the ordinal alone as (net <ordinal>).
+
+  * KiCad 10 (.kicad_pcb version 20260206): no net table, no ordinals --
+    pads/tracks/vias/zones all carry the name inline as (net "name").
+
+The KiCad 9 case is the one the initial KiCad 10 support (commit 0bc6aaf)
+silently regressed: the integer ordinal in (net 2) was mis-read as a net
+*name* "2", so every track/via resolved to net_id 0 and all per-net trace
+statistics collapsed to zero.  These tests fail loudly if that returns.
+"""
+
+import importlib.util
+import os
+import sys
+import tempfile
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_EXPORT_PY = os.path.join(_HERE, os.pardir, "tools", "kicad-export.py")
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("kicad_export", _EXPORT_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+kx = _load_module()
+
+
+# A resistor across VCC (net 2) and GND (net 1), one VCC track segment + via,
+# and a GND zone -- enough to exercise pad / segment / via / zone net refs.
+KICAD9_PCB = """\
+(kicad_pcb
+  (version 20241229) (generator "pcbnew") (generator_version "9.0")
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "VCC")
+  (footprint "R_0603"
+    (layer "F.Cu") (at 10 10 0)
+    (property "Reference" "R1") (property "Value" "10k")
+    (pad "1" smd roundrect (at -0.8 0) (net 2 "VCC"))
+    (pad "2" smd roundrect (at 0.8 0) (net 1 "GND"))
+  )
+  (segment (start 10 10) (end 20 10) (width 0.25) (layer "F.Cu") (net 2))
+  (segment (start 20 10) (end 30 10) (width 0.25) (layer "F.Cu") (net 2))
+  (via (at 20 10) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 2))
+  (zone (net 1) (net_name "GND") (layer "B.Cu"))
+)
+"""
+
+# Same board saved by KiCad 10: no net table, ordinals gone, names inline.
+KICAD10_PCB = """\
+(kicad_pcb
+  (version 20260206) (generator "pcbnew") (generator_version "10.0")
+  (footprint "R_0603"
+    (layer "F.Cu") (at 10 10 0)
+    (property "Reference" "R1") (property "Value" "10k")
+    (pad "1" smd roundrect (at -0.8 0) (net "VCC"))
+    (pad "2" smd roundrect (at 0.8 0) (net "GND"))
+  )
+  (segment (start 10 10) (end 20 10) (width 0.25) (layer "F.Cu") (net "VCC"))
+  (segment (start 20 10) (end 30 10) (width 0.25) (layer "F.Cu") (net "VCC"))
+  (via (at 20 10) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net "VCC"))
+  (zone (net "GND") (net_name "GND") (layer "B.Cu"))
+)
+"""
+
+
+def _parse(text):
+    fd, path = tempfile.mkstemp(suffix=".kicad_pcb")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        return kx.parse_board(path)
+    finally:
+        os.remove(path)
+
+
+_failures = []
+
+
+def check(cond, msg):
+    print(("  PASS: " if cond else "  FAIL: ") + msg)
+    if not cond:
+        _failures.append(msg)
+
+
+def test_kicad9():
+    print("KiCad 9 (top-level net table + integer ordinals):")
+    bd = _parse(KICAD9_PCB)
+
+    pad_nets = {p["name"]: (p["net_id"], p["net_name"])
+                for f in bd["footprints"] for p in f["pads"]}
+    check(pad_nets["1"] == (2, "VCC"), f"pad 1 -> VCC(2), got {pad_nets['1']}")
+    check(pad_nets["2"] == (1, "GND"), f"pad 2 -> GND(1), got {pad_nets['2']}")
+
+    seg_ids = [s["net_id"] for s in bd["segments"]]
+    check(seg_ids == [2, 2], f"segment ordinals resolve to [2, 2], got {seg_ids}")
+
+    via_ids = [v["net_id"] for v in bd["vias"]]
+    check(via_ids == [2], f"via ordinal resolves to [2], got {via_ids}")
+
+    # The regression guard: per-net trace stats must be non-zero for VCC.
+    sig = {s["name"]: s for s in kx.compute_signal_stats(
+        bd["segments"], bd["vias"], bd["nets"])}
+    check(sig["VCC"]["trace_length_mm"] == 20.0,
+          f"VCC trace length 20mm, got {sig['VCC']['trace_length_mm']}")
+    check(sig["VCC"]["via_count"] == 1,
+          f"VCC via_count 1, got {sig['VCC']['via_count']}")
+
+    zone_nets = [(z["net_id"], z["net_name"]) for z in bd["zones"]]
+    check(zone_nets == [(1, "GND")], f"zone -> GND(1), got {zone_nets}")
+
+
+def test_kicad10():
+    print("KiCad 10 (no net table, name-only inline refs):")
+    bd = _parse(KICAD10_PCB)
+
+    # Ordinals are synthesized in discovery order; 0 reserved for unconnected.
+    check(bd["nets"].get(0) == "", "net_id 0 reserved for unconnected net")
+    name_to_id = {v: k for k, v in bd["nets"].items()}
+    check("VCC" in name_to_id and "GND" in name_to_id,
+          f"VCC and GND present in synthesized net table, got {bd['nets']}")
+
+    pad_nets = {p["name"]: p["net_name"]
+                for f in bd["footprints"] for p in f["pads"]}
+    check(pad_nets == {"1": "VCC", "2": "GND"},
+          f"pads resolve to names, got {pad_nets}")
+
+    # Every pad/segment/via ordinal must be a real (non-zero) synthesized id.
+    all_ids = ([p["net_id"] for f in bd["footprints"] for p in f["pads"]]
+               + [s["net_id"] for s in bd["segments"]]
+               + [v["net_id"] for v in bd["vias"]])
+    check(all(i != 0 for i in all_ids),
+          f"no name-only ref collapses to net_id 0, got {all_ids}")
+
+    sig = {s["name"]: s for s in kx.compute_signal_stats(
+        bd["segments"], bd["vias"], bd["nets"])}
+    check(sig["VCC"]["trace_length_mm"] == 20.0,
+          f"VCC trace length 20mm, got {sig['VCC']['trace_length_mm']}")
+    check(sig["VCC"]["via_count"] == 1,
+          f"VCC via_count 1, got {sig['VCC']['via_count']}")
+
+
+def main():
+    test_kicad9()
+    test_kicad10()
+    print()
+    if _failures:
+        print(f"FAILED ({len(_failures)} check(s))")
+        sys.exit(1)
+    print("All checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/kicad-export.py
+++ b/tools/kicad-export.py
@@ -165,6 +165,20 @@ def _to_int(val):
             return 0
 
 
+def _is_int_token(tok):
+    """True if tok is a bare integer literal like '0', '185', '-1'.
+
+    Used to tell a KiCad 9 net ordinal (an integer) apart from a KiCad 10
+    net name (an arbitrary string) inside a two-element (net ...) reference.
+    Every S-expression atom reaches us as a string, so this is a syntactic
+    check, not an isinstance check.
+    """
+    if not isinstance(tok, str) or not tok:
+        return False
+    body = tok[1:] if tok[0] in '+-' else tok
+    return body.isdigit()
+
+
 def _get_scalar(node, tag):
     """Get first scalar value after tag in a child list: (tag value) -> value."""
     child = find_one(node, tag)
@@ -586,19 +600,26 @@ def _extract_layers(sexpr):
 def _resolve_net(net_node, name_to_id):
     """Return (net_id, net_name) handling KiCad 9 and KiCad 10 formats.
 
-    KiCad 9: pads/tracks/vias/zones use (net N "Name") -- explicit integer
-        ID + name.
-    KiCad 10: same nodes use (net "Name") only -- the ID is no longer
-        carried inline, so we look it up in the synthesized name_to_id map
-        produced by _extract_nets.
+    KiCad 9: pads carry (net N "Name") -- explicit integer ordinal + name;
+        tracks, vias and zones carry the ordinal alone as (net N).
+    KiCad 10: pads/tracks/vias/zones all carry (net "Name") only -- the
+        integer ordinal is gone, so we look the id up in the synthesized
+        name_to_id map produced by _extract_nets.
     """
     if not net_node or len(net_node) < 2:
         return 0, ""
-    # KiCad 9: 3 elements (net id "name") with int id and string name.
+    # KiCad 9 pad: 3 elements (net id "name") with int id and string name.
     if len(net_node) >= 3 and isinstance(net_node[2], str):
         net_id = _to_int(net_node[1])
         if net_id is not None:
             return net_id, net_node[2]
+    # KiCad 9 track/via/zone: 2 elements (net <ordinal>) -- a bare integer id.
+    # This MUST be checked before the KiCad 10 name branch: every S-expression
+    # atom reaches us as a string, so an ordinal like "185" would otherwise be
+    # mistaken for a net *name*, miss the name_to_id lookup, and collapse to
+    # net_id 0 -- zeroing every per-net trace statistic on KiCad 9 boards.
+    if _is_int_token(net_node[1]):
+        return _to_int(net_node[1]), ""
     # KiCad 10: 2 elements (net "name").
     if isinstance(net_node[1], str):
         name = net_node[1]
@@ -609,9 +630,9 @@ def _resolve_net(net_node, name_to_id):
 def _extract_nets(sexpr):
     """Extract net definitions.  Returns (nets_by_id, name_to_id).
 
-    KiCad 9 (.kicad_pcb up to v20231120): top-level (net N "name") blocks
+    KiCad 9 (.kicad_pcb version 20241229): top-level (net N "name") blocks
         give the canonical id<->name map.
-    KiCad 10 (v20260206 onward): no top-level (net N "name") -- net names
+    KiCad 10 (version 20260206): no top-level (net N "name") -- net names
         only appear inline as (net "name") inside pads/segments/vias/zones.
         We synthesize sequential ids (starting at 1) by discovery order so
         downstream code keeps working unchanged.


### PR DESCRIPTION
## Summary

Fixes a regression in the KiCad 10 net-format support added in `0bc6aaf` (@inktomi) that left **KiCad 9 boards with zeroed per-net trace statistics**. This builds on that commit rather than replacing it — `0bc6aaf` stays in history and its KiCad 10 path is unchanged.

## The bug

`0bc6aaf` added support for KiCad 10's name-only net references, `(net "GND")`. But its `_resolve_net()` treated *every* two-element `(net X)` node as a name. Because the S-expression tokenizer yields every atom as a string, KiCad 9's bare integer ordinal refs — `(net 185)` on tracks/vias/zones — were mistaken for net *names*, missed the `name_to_id` lookup, and resolved to `net_id 0`. Every per-net trace statistic then collapsed to zero.

Verified on a real KiCad 9 board (`version 20241229`): **100% of 4358 segments and 1050 vias regressed to `net_id 0`; 0 of 438 signals reported any trace length.**

## The fix

In `_resolve_net()`, resolve a two-element `(net <ordinal>)` as a KiCad 9 integer id — via a new `_is_int_token` helper, checked *before* the KiCad 10 name branch. This tells a KiCad 9 ordinal `(net 185)` apart from a KiCad 10 name `(net "GND")`. The KiCad 10 name-only path from `0bc6aaf` is unchanged, and `_extract_nets()` is untouched.

## Verification (real projects, both formats)

| Project | KiCad | Result |
|---|---|---|
| HMI5-ICT | 9 (`20241229`) | 307/438 signals with real trace length restored; 0 refs collapse to `net_id 0` |
| Debug-Test | 10 (`20260206`) | full schematic + board export, identical to before the fix |

## Tests

Adds `tests/test_kicad_export.py` — standalone, stdlib-only, with inline synthetic KiCad 9 and KiCad 10 board fixtures guarding both net-reference formats (the regression guard `0bc6aaf` lacked). Run:

```bash
python tests/test_kicad_export.py
```

Also documents KiCad 10 support in `README.md` and `docs/KiCad_Review_Guide.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
